### PR TITLE
Correct handling of Ctrl+Return/Enter hot-key.

### DIFF
--- a/src/hotkey/hotkey_item.cpp
+++ b/src/hotkey/hotkey_item.cpp
@@ -97,7 +97,11 @@ hotkey::hotkey_item& get_hotkey(int character, int keycode,
 	bool found = false;
 
 	for (itor = hotkeys_.begin(); itor != hotkeys_.end(); ++itor) {
-		if (itor->get_character() != -1) {
+		// Special case for Ctrl+Return/Enter keys, which gets resolved to Ctrl-j and Ctrl-m characters (LF and CR respectively).
+		// In such cases, do not match by character but go straight to key code.
+		if (itor->get_character() != -1 &&
+			!(tolower(character) == 'j' && keycode != SDLK_j) &&
+			!(tolower(character) == 'm' && keycode != SDLK_m)) {
 			if (character == itor->get_character()) {
 				if (ctrl == itor->get_ctrl()
 						&& cmd == itor->get_cmd()
@@ -532,7 +536,12 @@ void hotkey_item::set_key(int character, int keycode,
 		character -= 32; }
 
 	// We handle simple cases by character, others by the actual key.
-	if (isprint(character) && !isspace(character)) {
+	// @ and ` are exceptions related to the space character. Without these, combinations involving Ctrl or Ctrl+Shift often resolve the character value to null (or @ and `).
+	// j and m exceptions are to catch Ctrl+Return/Enter, which is interpreted as Ctrl+j and Ctrl+m characters (LF and CR respectively).
+	if (isprint(character) && !isspace(character) &&
+		character != '@' && character != '`' &&
+		!(tolower(character) == 'j' && keycode != SDLK_j) &&
+		!(tolower(character) == 'm' && keycode != SDLK_m)) {
 		character_ = character;
 		ctrl_      = ctrl;
 		cmd_       = cmd;


### PR DESCRIPTION
Added special handling for j and m characters, where their respective key codes do not match the j and m buttons on the keyboard.
This most likely means that they have come from Ctrl+Return/Enter keys, which resolves to Ctrl+j and Ctrl+m characters.

As a bonus, also corrected unexpected behaviour when attempting combinations such as Ctrl+: or Ctrl+F1. Previously they would resolve to Ctrl+` or Ctrl+@, at least in Windows.