### PR TITLE
Resolve colour cursor blending issue in SDL 2.0

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -292,6 +292,11 @@ void undraw(surface screen)
 		return;
 	}
 
+#if SDL_VERSION_ATLEAST(2,0,0)
+	// Colour cursors leave behind a trail in SDL2, particularly noticeable when the cursor gets locked during reading a new hot-key.
+	// Disabling blending for the undraw appears to resolve the issue.
+	SDL_SetSurfaceBlendMode (cursor_buf, SDL_BLENDMODE_NONE);
+#endif
 	SDL_Rect area = sdl::create_rect(cursor_x - shift_x[current_cursor]
 			, cursor_y - shift_y[current_cursor]
 			, cursor_buf->w


### PR DESCRIPTION
With the addition of surface blending in SDL2, having colour cursors enabled results in a faint trail of mouse cursors being left behind. It is stronger when the mouse moves more slowly and definitely noticeable when the cursor is locked for the adding new hot-key function.

This is related to https://github.com/wesnoth/wesnoth/pull/473 but unlike that issue, this was a problem for me in Windows. I do not know if it is also an issue with Linux and OS X builds.