### PR TITLE
Work-Around for Bug #18637

### DIFF
--- a/src/whiteboard/move.cpp
+++ b/src/whiteboard/move.cpp
@@ -144,6 +144,11 @@ move::move(config const& cfg, bool hidden)
 
 void move::init()
 {
+	// If a unit is invalid, return immediately.
+	// At the very least, this will stop crashes when trying to plan moves on planned recruits.
+	if (get_unit() == NULL)
+		return;
+
 	assert(get_unit());
 	unit_id_ = get_unit()->id();
 


### PR DESCRIPTION
Attempt to work-around bug #18637, where planning moves on planned recruits results in a crash (because get_unit() is null when move::init() is called).

This isn't a comprehensive fix because clicking on a planned recruit will still result in the usual display feedback for planning a move. The difference here is that attempting to place a planned move will result in nothing happening when the mouse button is clicked (as opposed to the assertion failure or crash which happens currently). It is better than nothing, I believe, unless there are negative side-effects of which I am unaware of.