### PR TITLE
Align default quit hot-key with conventions (fixes #2397)

### DIFF
--- a/data/core/hotkeys.cfg
+++ b/data/core/hotkeys.cfg
@@ -180,11 +180,7 @@
 [/hotkey]
 [hotkey]
     command=quit
-#ifdef APPLE
     key=w
-#else
-    key=q
-#endif
     {IF_APPLE_CMD_ELSE_CTRL}
 [/hotkey]
 [hotkey]
@@ -368,7 +364,6 @@
 [hotkey]
     command="quit-to-desktop"
     key="q"
-    shift=yes
     ctrl=yes
 [/hotkey]
 #endif


### PR DESCRIPTION
Switch quit to title-screen from Ctrl+Q to Ctrl+W (OSX already uses Cmd+W) and quit-to-desktop from Ctrl+Shift+Q to Ctrl+Q.